### PR TITLE
Fixes #5: Move away from uuids as primary identifiers

### DIFF
--- a/Entity/Traits/IdentifiableTrait.php
+++ b/Entity/Traits/IdentifiableTrait.php
@@ -15,7 +15,7 @@ trait IdentifiableTrait
      *
      * @ORM\Id
      * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 

--- a/Entity/Traits/IdentifiableTrait.php
+++ b/Entity/Traits/IdentifiableTrait.php
@@ -3,8 +3,6 @@
 namespace DigipolisGent\SettingBundle\Entity\Traits;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * Trait IdentifiableTrait
@@ -16,13 +14,12 @@ trait IdentifiableTrait
      * @var string $id
      *
      * @ORM\Id
-     * @ORM\Column(type="uuid", unique=true)
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class=UuidGenerator::class)
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
     protected $id;
 
-    public function getId(): ?Uuid
+    public function getId(): ?int
     {
         return $this->id;
     }


### PR DESCRIPTION
I don't know why we chose to use uuids as primary identifiers all those
years ago, but it's impractical when looking at a database when you're
debugging something, I can imagine it's slower (to join, index, filter,
... I have no actual data about this, it's an assumption), it's not the
industry standard, and it's causing issues while upgrading to Symfony 5
because doctrine/dbal no longer supports it, and the implementation
Symfony created for it vastly differs from the previous implementation
by doctrine, while the benefits are... non-existent as far as I'm aware.

This is a breaking change, users of this bundle will need to provide
their own migrations for this change.